### PR TITLE
v1.3.0: remote typing without keyboard switching, clipboard sync, VPN-proof scan, CI bumps

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,10 +15,10 @@ jobs:
     environment: pypi
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -47,7 +47,7 @@ jobs:
           cp android/app/build/outputs/apk/release/app-release.apk RemotePhone-${VERSION}.apk
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: apk
           path: RemotePhone-*.apk
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create client tarball
         run: |
@@ -67,7 +67,7 @@ jobs:
             run.sh pyproject.toml README.md LICENSE remotephone/
 
       - name: Upload client artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-client
           path: RemotePhone-linux-*.tar.gz
@@ -78,15 +78,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: apk
 
       - name: Download Linux client
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-client
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ The launcher script creates a virtual environment and installs the package into 
 | Any typing | Text input into focused field |
 | Backspace | Delete character (or Back if no text field) |
 | Delete | Delete forward |
-| Ctrl+A / C / X / V | Select all / Copy / Cut / Paste |
+| Ctrl+A / C / X | Select all / Copy / Cut (copy and cut also land on the desktop clipboard) |
+| Ctrl+V | Paste the desktop clipboard into the phone |
 | Enter | Confirm / IME action / PIN submit |
 
 ### Keyboard and Text Input

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The launcher script creates a virtual environment and installs the package into 
 
 ### Keyboard and Text Input
 
-When you tap a text field on the phone, you can type directly from your desktop keyboard. For reliable typing in every app, including text fields inside web pages, enable the **RemotePhone Keyboard** (the app's Remote Typing Setup card opens the settings) and select it while mirroring; typing then goes through Android's real input pipeline. Without it, typing falls back to accessibility text actions, which work in native text fields but are unreliable in browsers.
+When you tap a text field on the phone, you can type directly from your desktop keyboard. On Android 13+ this goes through the real input pipeline automatically, works in every app including text fields inside web pages, and your normal on-screen keyboard stays selected. On Android 12 and older, enable and select the **RemotePhone Keyboard** (the app's Remote Typing Setup card opens the settings) for the same reliability; without it, typing falls back to accessibility text actions, which work in native text fields but are unreliable in browsers.
 
 **PIN/Password fields** are handled specially — keyboard digits click the on-screen PIN pad buttons via the accessibility tree, and Enter searches for the confirm/OK button.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The launcher script creates a virtual environment and installs the package into 
 
 ### Keyboard and Text Input
 
-When you tap a text field on the phone, you can type directly from your desktop keyboard. The text is inserted at the cursor position with full cursor-aware editing.
+When you tap a text field on the phone, you can type directly from your desktop keyboard. For reliable typing in every app, including text fields inside web pages, enable the **RemotePhone Keyboard** (the app's Remote Typing Setup card opens the settings) and select it while mirroring; typing then goes through Android's real input pipeline. Without it, typing falls back to accessibility text actions, which work in native text fields but are unreliable in browsers.
 
 **PIN/Password fields** are handled specially — keyboard digits click the on-screen PIN pad buttons via the accessibility tree, and Enter searches for the confirm/OK button.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.remotephone"
         minSdk = 24
         targetSdk = 34
-        versionCode = 5
-        versionName = "1.2.0"
+        versionCode = 6
+        versionName = "1.3.0"
     }
 
     signingConfigs {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,6 +43,19 @@
                 android:resource="@xml/accessibility_service_config" />
         </service>
 
+        <service
+            android:name=".RemoteInputMethodService"
+            android:exported="true"
+            android:label="@string/ime_label"
+            android:permission="android.permission.BIND_INPUT_METHOD">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/method" />
+        </service>
+
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/remotephone/MainActivity.kt
+++ b/android/app/src/main/java/com/remotephone/MainActivity.kt
@@ -6,6 +6,7 @@ import android.media.projection.MediaProjectionManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.Switch
 import android.widget.TextView
@@ -25,6 +26,8 @@ class MainActivity : ComponentActivity() {
     private lateinit var audioSubtext: TextView
     private lateinit var accessibilityStatus: TextView
     private lateinit var accessibilityButton: Button
+    private lateinit var keyboardStatus: TextView
+    private lateinit var keyboardButton: Button
 
     private var isStreaming = false
 
@@ -53,6 +56,8 @@ class MainActivity : ComponentActivity() {
         audioSubtext = findViewById(R.id.audioSubtext)
         accessibilityStatus = findViewById(R.id.accessibilityStatus)
         accessibilityButton = findViewById(R.id.accessibilityButton)
+        keyboardStatus = findViewById(R.id.keyboardStatus)
+        keyboardButton = findViewById(R.id.keyboardButton)
 
         // Show device IP
         ipText.text = getDeviceIpAddress()
@@ -86,6 +91,15 @@ class MainActivity : ComponentActivity() {
             startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
         }
 
+        // Keyboard button: enable in settings first, then just switch keyboards
+        keyboardButton.setOnClickListener {
+            if (isRemoteKeyboardEnabled()) {
+                (getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager).showInputMethodPicker()
+            } else {
+                startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+            }
+        }
+
         // Request notification permission on Android 13+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 100)
@@ -95,6 +109,7 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         updateAccessibilityStatus()
+        updateKeyboardStatus()
         ipText.text = getDeviceIpAddress()
     }
 
@@ -147,6 +162,32 @@ class MainActivity : ComponentActivity() {
                 accessibilityStatus.text = "Accessibility Service: Not enabled"
             }
             accessibilityStatus.setTextColor(getColor(R.color.status_amber))
+        }
+    }
+
+    private fun isRemoteKeyboardEnabled(): Boolean =
+        Settings.Secure.getString(contentResolver, Settings.Secure.ENABLED_INPUT_METHODS)
+            ?.contains(packageName) == true
+
+    private fun updateKeyboardStatus() {
+        val selected = Settings.Secure.getString(contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+            ?.startsWith(packageName) == true
+        when {
+            selected -> {
+                keyboardStatus.text = "RemotePhone Keyboard: \u2713 Active"
+                keyboardStatus.setTextColor(getColor(R.color.status_green))
+                keyboardButton.text = "Switch keyboard"
+            }
+            isRemoteKeyboardEnabled() -> {
+                keyboardStatus.text = "RemotePhone Keyboard: enabled, not selected"
+                keyboardStatus.setTextColor(getColor(R.color.status_amber))
+                keyboardButton.text = "Switch keyboard"
+            }
+            else -> {
+                keyboardStatus.text = "RemotePhone Keyboard: not enabled"
+                keyboardStatus.setTextColor(getColor(R.color.status_amber))
+                keyboardButton.text = "Enable RemotePhone Keyboard"
+            }
         }
     }
 

--- a/android/app/src/main/java/com/remotephone/MainActivity.kt
+++ b/android/app/src/main/java/com/remotephone/MainActivity.kt
@@ -91,6 +91,12 @@ class MainActivity : ComponentActivity() {
             startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
         }
 
+        // Android 13+ types through the accessibility service's own input
+        // connection, so the extra keyboard is only needed on older versions
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            findViewById<android.view.View>(R.id.keyboardCard).visibility = android.view.View.GONE
+        }
+
         // Keyboard button: enable in settings first, then just switch keyboards
         keyboardButton.setOnClickListener {
             if (isRemoteKeyboardEnabled()) {
@@ -109,7 +115,7 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         updateAccessibilityStatus()
-        updateKeyboardStatus()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) updateKeyboardStatus()
         ipText.text = getDeviceIpAddress()
     }
 

--- a/android/app/src/main/java/com/remotephone/MainActivity.kt
+++ b/android/app/src/main/java/com/remotephone/MainActivity.kt
@@ -165,9 +165,12 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun isRemoteKeyboardEnabled(): Boolean =
-        Settings.Secure.getString(contentResolver, Settings.Secure.ENABLED_INPUT_METHODS)
-            ?.contains(packageName) == true
+    private fun isRemoteKeyboardEnabled(): Boolean {
+        // Settings.Secure.ENABLED_INPUT_METHODS is not readable from targetSdk 34;
+        // InputMethodManager is the supported way to list enabled keyboards.
+        val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+        return imm.enabledInputMethodList.any { it.packageName == packageName }
+    }
 
     private fun updateKeyboardStatus() {
         val selected = Settings.Secure.getString(contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)

--- a/android/app/src/main/java/com/remotephone/MainActivity.kt
+++ b/android/app/src/main/java/com/remotephone/MainActivity.kt
@@ -56,8 +56,6 @@ class MainActivity : ComponentActivity() {
         audioSubtext = findViewById(R.id.audioSubtext)
         accessibilityStatus = findViewById(R.id.accessibilityStatus)
         accessibilityButton = findViewById(R.id.accessibilityButton)
-        keyboardStatus = findViewById(R.id.keyboardStatus)
-        keyboardButton = findViewById(R.id.keyboardButton)
 
         // Show device IP
         ipText.text = getDeviceIpAddress()
@@ -92,17 +90,18 @@ class MainActivity : ComponentActivity() {
         }
 
         // Android 13+ types through the accessibility service's own input
-        // connection, so the extra keyboard is only needed on older versions
+        // connection, so the extra keyboard (and its card) is only wired on older versions
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             findViewById<android.view.View>(R.id.keyboardCard).visibility = android.view.View.GONE
-        }
-
-        // Keyboard button: enable in settings first, then just switch keyboards
-        keyboardButton.setOnClickListener {
-            if (isRemoteKeyboardEnabled()) {
-                (getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager).showInputMethodPicker()
-            } else {
-                startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+        } else {
+            keyboardStatus = findViewById(R.id.keyboardStatus)
+            keyboardButton = findViewById(R.id.keyboardButton)
+            keyboardButton.setOnClickListener {
+                if (isRemoteKeyboardEnabled()) {
+                    (getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager).showInputMethodPicker()
+                } else {
+                    startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+                }
             }
         }
 

--- a/android/app/src/main/java/com/remotephone/MirrorWebSocketServer.kt
+++ b/android/app/src/main/java/com/remotephone/MirrorWebSocketServer.kt
@@ -91,15 +91,21 @@ class MirrorWebSocketServer(
     }
 
     private fun sendClipboard(conn: WebSocket) {
-        try {
+        // Only the active IME may read the clipboard; when that fails, use the
+        // selection the accessibility service captured while performing the copy.
+        val text = try {
             val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            val text = cm.primaryClip?.getItemAt(0)?.coerceToText(context)?.toString()
+            cm.primaryClip?.getItemAt(0)?.coerceToText(context)?.toString()
+        } catch (e: Exception) {
+            null
+        } ?: RemoteAccessibilityService.lastCopiedText
+        try {
             if (!text.isNullOrEmpty() && conn.isOpen) {
                 conn.send(JSONObject().put("type", "clipboard").put("content", text).toString())
                 Log.i(TAG, "Sent clipboard to client (${text.length} chars)")
             }
         } catch (e: Exception) {
-            Log.w(TAG, "Clipboard read failed (RemotePhone Keyboard not selected?)", e)
+            Log.w(TAG, "Clipboard send failed", e)
         }
     }
 

--- a/android/app/src/main/java/com/remotephone/MirrorWebSocketServer.kt
+++ b/android/app/src/main/java/com/remotephone/MirrorWebSocketServer.kt
@@ -1,6 +1,10 @@
 package com.remotephone
 
+import android.content.ClipboardManager
+import android.content.Context
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import org.java_websocket.WebSocket
 import org.java_websocket.handshake.ClientHandshake
@@ -11,11 +15,14 @@ import java.nio.ByteBuffer
 
 class MirrorWebSocketServer(
     port: Int,
+    private val context: Context,
     private val screenWidth: Int,
     private val screenHeight: Int,
     private val audioAvailable: Boolean,
     private val onControlCommand: (String) -> Unit
 ) : WebSocketServer(InetSocketAddress(port)) {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     companion object {
         private const val TAG = "MirrorWSServer"
@@ -62,6 +69,13 @@ class MirrorWebSocketServer(
                     val enabled = json.getBoolean("enabled")
                     ScreenCaptureService.toggleAudio(enabled)
                 }
+                "copy", "cut" -> {
+                    onControlCommand(message)
+                    // Mirror the phone clipboard back once the action has landed.
+                    // Reading works while the RemotePhone Keyboard is the selected
+                    // IME (the Android 10+ background-clipboard exemption).
+                    mainHandler.postDelayed({ sendClipboard(conn) }, 250)
+                }
                 else -> {
                     // Forward all other messages as control commands
                     onControlCommand(message)
@@ -74,6 +88,19 @@ class MirrorWebSocketServer(
 
     override fun onMessage(conn: WebSocket, message: ByteBuffer) {
         // Not expected from client side
+    }
+
+    private fun sendClipboard(conn: WebSocket) {
+        try {
+            val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val text = cm.primaryClip?.getItemAt(0)?.coerceToText(context)?.toString()
+            if (!text.isNullOrEmpty() && conn.isOpen) {
+                conn.send(JSONObject().put("type", "clipboard").put("content", text).toString())
+                Log.i(TAG, "Sent clipboard to client (${text.length} chars)")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Clipboard read failed (RemotePhone Keyboard not selected?)", e)
+        }
     }
 
     override fun onError(conn: WebSocket?, ex: Exception) {

--- a/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
+++ b/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
@@ -9,8 +9,10 @@ import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
 import android.util.Log
+import android.view.KeyEvent
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import androidx.annotation.RequiresApi
 import org.json.JSONObject
 
 class RemoteAccessibilityService : AccessibilityService() {
@@ -18,6 +20,11 @@ class RemoteAccessibilityService : AccessibilityService() {
     companion object {
         private const val TAG = "RemoteAccessibility"
         private var instance: RemoteAccessibilityService? = null
+
+        /** Selection captured at copy/cut time, for clients when the clipboard is unreadable. */
+        @Volatile
+        var lastCopiedText: String? = null
+            private set
 
         fun isRunning(): Boolean = instance != null
 
@@ -55,32 +62,41 @@ class RemoteAccessibilityService : AccessibilityService() {
                         cmd.getDouble("dy").toFloat()
                     )
                     "key" -> service.performKey(cmd.getString("action"))
-                    // Text editing goes through the RemotePhone keyboard (real input
-                    // pipeline, reliable in web fields) when it is the active IME;
-                    // otherwise through the accessibility node actions below.
+                    // Text editing prefers the real input pipeline: on Android 13+ the
+                    // service holds its own InputConnection (flagInputMethodEditor), so
+                    // the user's keyboard stays selected. Next preference is the
+                    // RemotePhone Keyboard when it is the active IME (pre-13), and the
+                    // accessibility node actions below are the last resort.
                     "text" -> {
                         val content = cmd.getString("content")
-                        if (!RemoteInputMethodService.typeText(content)) service.performTextInput(content)
+                        if (!service.imeCommit(content) &&
+                            !RemoteInputMethodService.typeText(content)) service.performTextInput(content)
                     }
                     "backspace" -> {
-                        if (!RemoteInputMethodService.backspace()) service.performBackspace()
+                        if (!service.imeKey(KeyEvent.KEYCODE_DEL) &&
+                            !RemoteInputMethodService.backspace()) service.performBackspace()
                     }
                     "delete" -> {
-                        if (!RemoteInputMethodService.forwardDelete()) service.performDelete()
+                        if (!service.imeKey(KeyEvent.KEYCODE_FORWARD_DEL) &&
+                            !RemoteInputMethodService.forwardDelete()) service.performDelete()
                     }
                     "select_all" -> {
-                        if (!RemoteInputMethodService.contextMenu(android.R.id.selectAll)) service.performSelectAll()
+                        if (!service.imeContextMenu(android.R.id.selectAll) &&
+                            !RemoteInputMethodService.contextMenu(android.R.id.selectAll)) service.performSelectAll()
                     }
                     "copy" -> {
-                        if (!RemoteInputMethodService.contextMenu(android.R.id.copy))
+                        if (!service.imeCopy(cut = false) &&
+                            !RemoteInputMethodService.contextMenu(android.R.id.copy))
                             service.performClipboardAction(AccessibilityNodeInfo.ACTION_COPY)
                     }
                     "cut" -> {
-                        if (!RemoteInputMethodService.contextMenu(android.R.id.cut))
+                        if (!service.imeCopy(cut = true) &&
+                            !RemoteInputMethodService.contextMenu(android.R.id.cut))
                             service.performClipboardAction(AccessibilityNodeInfo.ACTION_CUT)
                     }
                     "paste" -> {
-                        if (!RemoteInputMethodService.contextMenu(android.R.id.paste))
+                        if (!service.imeContextMenu(android.R.id.paste) &&
+                            !RemoteInputMethodService.contextMenu(android.R.id.paste))
                             service.performClipboardAction(AccessibilityNodeInfo.ACTION_PASTE)
                     }
                 }
@@ -108,6 +124,59 @@ class RemoteAccessibilityService : AccessibilityService() {
 
     override fun onInterrupt() {
         // Required override
+    }
+
+    // ---- Input via the service's own InputConnection (Android 13+) ----
+    // Null when the OS is older or no editor is focused; callers then fall back.
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun imeIc() = inputMethod?.currentInputConnection
+
+    private fun imeCommit(content: String): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+        val ic = imeIc() ?: return false
+        if (content == "\n") {
+            // Enter as a key event: pages and search boxes listen for the key itself
+            ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+            ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
+        } else {
+            ic.commitText(content, 1, null)
+        }
+        return true
+    }
+
+    private fun imeKey(code: Int): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+        val ic = imeIc() ?: return false
+        ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, code))
+        ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, code))
+        return true
+    }
+
+    private fun imeContextMenu(id: Int): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+        val ic = imeIc() ?: return false
+        ic.performContextMenuAction(id)
+        return true
+    }
+
+    /** Copy/cut, capturing the selection so the server can mirror it to clients
+     *  even though only the active IME may read the clipboard. */
+    private fun imeCopy(cut: Boolean): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+        val ic = imeIc() ?: return false
+        try {
+            val st = ic.getSurroundingText(5000, 5000, 0)
+            if (st != null) {
+                val a = minOf(st.selectionStart, st.selectionEnd).coerceIn(0, st.text.length)
+                val b = maxOf(st.selectionStart, st.selectionEnd).coerceIn(0, st.text.length)
+                if (a != b) lastCopiedText = st.text.substring(a, b).toString()
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Selection read failed", e)
+        }
+        ic.performContextMenuAction(if (cut) android.R.id.cut else android.R.id.copy)
+        return true
     }
 
     // ---- Screen wake ----

--- a/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
+++ b/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
@@ -12,7 +12,6 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import androidx.annotation.RequiresApi
 import org.json.JSONObject
 
 class RemoteAccessibilityService : AccessibilityService() {
@@ -127,46 +126,38 @@ class RemoteAccessibilityService : AccessibilityService() {
     }
 
     // ---- Input via the service's own InputConnection (Android 13+) ----
-    // Null when the OS is older or no editor is focused; callers then fall back.
+    // Each returns false when the OS is older or no editor is focused; callers
+    // then fall back to the RemotePhone Keyboard or accessibility node actions.
 
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    private fun imeIc() = inputMethod?.currentInputConnection
+    // The service's own connection to the focused editor, or null below API 33
+    // / when nothing is focused. The `?.apply { } != null` callers below run the
+    // block only when it exists and report whether they did, so the guard lives
+    // here once instead of in every command.
+    private fun imeIc() =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) inputMethod?.currentInputConnection else null
 
-    private fun imeCommit(content: String): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-        val ic = imeIc() ?: return false
+    private fun imeCommit(content: String) = imeIc()?.apply {
         if (content == "\n") {
             // Enter as a key event: pages and search boxes listen for the key itself
-            ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
-            ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
+            sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+            sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
         } else {
-            ic.commitText(content, 1, null)
+            commitText(content, 1, null)
         }
-        return true
-    }
+    } != null
 
-    private fun imeKey(code: Int): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-        val ic = imeIc() ?: return false
-        ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, code))
-        ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, code))
-        return true
-    }
+    private fun imeKey(code: Int) = imeIc()?.apply {
+        sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, code))
+        sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, code))
+    } != null
 
-    private fun imeContextMenu(id: Int): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-        val ic = imeIc() ?: return false
-        ic.performContextMenuAction(id)
-        return true
-    }
+    private fun imeContextMenu(id: Int) = imeIc()?.apply { performContextMenuAction(id) } != null
 
     /** Copy/cut, capturing the selection so the server can mirror it to clients
      *  even though only the active IME may read the clipboard. */
-    private fun imeCopy(cut: Boolean): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-        val ic = imeIc() ?: return false
+    private fun imeCopy(cut: Boolean) = imeIc()?.apply {
         try {
-            val st = ic.getSurroundingText(5000, 5000, 0)
+            val st = getSurroundingText(5000, 5000, 0)
             if (st != null) {
                 val a = minOf(st.selectionStart, st.selectionEnd).coerceIn(0, st.text.length)
                 val b = maxOf(st.selectionStart, st.selectionEnd).coerceIn(0, st.text.length)
@@ -175,9 +166,8 @@ class RemoteAccessibilityService : AccessibilityService() {
         } catch (e: Exception) {
             Log.w(TAG, "Selection read failed", e)
         }
-        ic.performContextMenuAction(if (cut) android.R.id.cut else android.R.id.copy)
-        return true
-    }
+        performContextMenuAction(if (cut) android.R.id.cut else android.R.id.copy)
+    } != null
 
     // ---- Screen wake ----
 

--- a/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
+++ b/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
@@ -55,13 +55,34 @@ class RemoteAccessibilityService : AccessibilityService() {
                         cmd.getDouble("dy").toFloat()
                     )
                     "key" -> service.performKey(cmd.getString("action"))
-                    "text" -> service.performTextInput(cmd.getString("content"))
-                    "backspace" -> service.performBackspace()
-                    "delete" -> service.performDelete()
-                    "select_all" -> service.performSelectAll()
-                    "copy" -> service.performClipboardAction(AccessibilityNodeInfo.ACTION_COPY)
-                    "cut" -> service.performClipboardAction(AccessibilityNodeInfo.ACTION_CUT)
-                    "paste" -> service.performClipboardAction(AccessibilityNodeInfo.ACTION_PASTE)
+                    // Text editing goes through the RemotePhone keyboard (real input
+                    // pipeline, reliable in web fields) when it is the active IME;
+                    // otherwise through the accessibility node actions below.
+                    "text" -> {
+                        val content = cmd.getString("content")
+                        if (!RemoteInputMethodService.typeText(content)) service.performTextInput(content)
+                    }
+                    "backspace" -> {
+                        if (!RemoteInputMethodService.backspace()) service.performBackspace()
+                    }
+                    "delete" -> {
+                        if (!RemoteInputMethodService.forwardDelete()) service.performDelete()
+                    }
+                    "select_all" -> {
+                        if (!RemoteInputMethodService.contextMenu(android.R.id.selectAll)) service.performSelectAll()
+                    }
+                    "copy" -> {
+                        if (!RemoteInputMethodService.contextMenu(android.R.id.copy))
+                            service.performClipboardAction(AccessibilityNodeInfo.ACTION_COPY)
+                    }
+                    "cut" -> {
+                        if (!RemoteInputMethodService.contextMenu(android.R.id.cut))
+                            service.performClipboardAction(AccessibilityNodeInfo.ACTION_CUT)
+                    }
+                    "paste" -> {
+                        if (!RemoteInputMethodService.contextMenu(android.R.id.paste))
+                            service.performClipboardAction(AccessibilityNodeInfo.ACTION_PASTE)
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error handling command: $json", e)

--- a/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
+++ b/android/app/src/main/java/com/remotephone/RemoteAccessibilityService.kt
@@ -68,11 +68,16 @@ class RemoteAccessibilityService : AccessibilityService() {
                     // accessibility node actions below are the last resort.
                     "text" -> {
                         val content = cmd.getString("content")
-                        if (!service.imeCommit(content) &&
+                        // PIN/password fields (incl. the lock screen) are button grids,
+                        // not text editors: only clicking the on-screen pad works, so
+                        // skip the input-connection paths for them.
+                        if (service.isPasswordFieldFocused()) service.performTextInput(content)
+                        else if (!service.imeCommit(content) &&
                             !RemoteInputMethodService.typeText(content)) service.performTextInput(content)
                     }
                     "backspace" -> {
-                        if (!service.imeKey(KeyEvent.KEYCODE_DEL) &&
+                        if (service.isPasswordFieldFocused()) service.performBackspace()
+                        else if (!service.imeKey(KeyEvent.KEYCODE_DEL) &&
                             !RemoteInputMethodService.backspace()) service.performBackspace()
                     }
                     "delete" -> {

--- a/android/app/src/main/java/com/remotephone/RemoteInputMethodService.kt
+++ b/android/app/src/main/java/com/remotephone/RemoteInputMethodService.kt
@@ -1,0 +1,84 @@
+package com.remotephone
+
+import android.content.Context
+import android.inputmethodservice.InputMethodService
+import android.view.Gravity
+import android.view.KeyEvent
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
+
+/**
+ * Minimal keyboard that lets the desktop client type through the real input
+ * pipeline (InputConnection) instead of accessibility SET_TEXT. Web fields,
+ * games and custom editors all honour this path because it is what a physical
+ * keyboard uses; the accessibility path stays as fallback for when this
+ * keyboard is not selected (and for the lock screen, where IMEs do not run).
+ */
+class RemoteInputMethodService : InputMethodService() {
+
+    companion object {
+        private var instance: RemoteInputMethodService? = null
+
+        private fun ic() = instance?.takeIf { it.editorActive }?.currentInputConnection
+
+        private fun key(ic: android.view.inputmethod.InputConnection, code: Int): Boolean {
+            ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, code))
+            return ic.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, code))
+        }
+
+        /** Each returns false when this keyboard is not active, so the caller can fall back. */
+        fun typeText(content: String): Boolean {
+            val ic = ic() ?: return false
+            // Enter as a key event: web pages and search boxes listen for the key itself
+            return if (content == "\n") key(ic, KeyEvent.KEYCODE_ENTER)
+            else ic.commitText(content, 1)
+        }
+
+        fun backspace(): Boolean = ic()?.let { key(it, KeyEvent.KEYCODE_DEL) } ?: false
+
+        fun forwardDelete(): Boolean = ic()?.let { key(it, KeyEvent.KEYCODE_FORWARD_DEL) } ?: false
+
+        fun contextMenu(id: Int): Boolean = ic()?.performContextMenuAction(id) ?: false
+    }
+
+    private var editorActive = false
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+
+    override fun onDestroy() {
+        instance = null
+        super.onDestroy()
+    }
+
+    override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
+        super.onStartInput(attribute, restarting)
+        // TYPE_NULL means no real editor is connected (dummy InputConnection)
+        editorActive = (attribute?.inputType ?: EditorInfo.TYPE_NULL) != EditorInfo.TYPE_NULL
+    }
+
+    override fun onFinishInput() {
+        editorActive = false
+        super.onFinishInput()
+    }
+
+    /**
+     * Instead of a key panel, show a slim bar so whoever holds the phone can
+     * see why no keyboard appears and switch back with one tap.
+     */
+    override fun onCreateInputView(): View = TextView(this).apply {
+        text = "RemotePhone keyboard active, tap to switch"
+        gravity = Gravity.CENTER
+        setPadding(24, 28, 24, 28)
+        setTextColor(getColor(R.color.text_secondary))
+        setBackgroundColor(getColor(R.color.card_bg))
+        setOnClickListener {
+            (getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                .showInputMethodPicker()
+        }
+    }
+}

--- a/android/app/src/main/java/com/remotephone/ScreenCaptureService.kt
+++ b/android/app/src/main/java/com/remotephone/ScreenCaptureService.kt
@@ -193,6 +193,7 @@ class ScreenCaptureService : Service() {
         // Start WebSocket server
         webSocketServer = MirrorWebSocketServer(
             port = WS_PORT,
+            context = this,
             screenWidth = screenWidth,
             screenHeight = screenHeight,
             audioAvailable = audioAvailable,

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -232,6 +232,53 @@
                 android:paddingEnd="0dp" />
         </LinearLayout>
 
+        <!-- Keyboard Setup Card -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:background="@drawable/card_background"
+            android:padding="16dp"
+            android:layout_marginTop="16dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="REMOTE TYPING SETUP"
+                android:textSize="11sp"
+                android:textColor="@color/text_hint"
+                android:letterSpacing="0.15" />
+
+            <TextView
+                android:id="@+id/keyboardStatus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="RemotePhone Keyboard: not enabled"
+                android:textSize="13sp"
+                android:textColor="@color/status_amber"
+                android:layout_marginTop="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Select the RemotePhone Keyboard while mirroring so desktop typing works in every app, including browser pages."
+                android:textSize="12sp"
+                android:textColor="@color/text_muted"
+                android:layout_marginTop="4dp" />
+
+            <Button
+                android:id="@+id/keyboardButton"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:text="Enable RemotePhone Keyboard"
+                android:textSize="12sp"
+                android:textColor="@color/accent_blue"
+                android:background="@android:color/transparent"
+                android:layout_marginTop="8dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp" />
+        </LinearLayout>
+
         <View
             android:layout_width="1dp"
             android:layout_height="48dp" />

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -232,8 +232,9 @@
                 android:paddingEnd="0dp" />
         </LinearLayout>
 
-        <!-- Keyboard Setup Card -->
+        <!-- Keyboard Setup Card (Android 12 and older only) -->
         <LinearLayout
+            android:id="@+id/keyboardCard"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">RemotePhone</string>
     <string name="accessibility_description">RemotePhone uses this service to receive touch and gesture commands from your computer, enabling remote control of your phone without USB debugging.</string>
+    <string name="ime_label">RemotePhone Keyboard</string>
 </resources>

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -2,6 +2,7 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityEventTypes="typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagInputMethodEditor"
     android:canPerformGestures="true"
     android:canRetrieveWindowContent="true"
     android:description="@string/accessibility_description"

--- a/android/app/src/main/res/xml/method.xml
+++ b/android/app/src/main/res/xml/method.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsSwitchingToNextInputMethod="true" />

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,3 @@
+Type into web pages and any app without switching keyboards (Android 13+),
+two-way clipboard sync between phone and desktop, smoother trackpad scroll
+and back gestures, finds the phone even behind a VPN, and a new app icon.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "remote-phone"
-version = "1.2.0"
+version = "1.3.0"
 description = "Mirror and control your Android phone from your desktop over WiFi"
 readme = "README.md"
 license = "MIT"

--- a/remotephone/network/scanner.py
+++ b/remotephone/network/scanner.py
@@ -8,8 +8,10 @@ not reported as devices.
 """
 
 import json
+import re
 import socket
 import logging
+import subprocess
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -21,17 +23,58 @@ log = logging.getLogger("scanner")
 DEFAULT_PORT = 8765
 CONNECT_TIMEOUT = 0.3  # seconds per TCP probe
 VERIFY_TIMEOUT = 1.0   # seconds for the WebSocket handshake + info reply
-MAX_WORKERS = 80       # parallel connection attempts
+MAX_WORKERS = 50       # parallel connection attempts (higher drops SYNs/handshakes to one phone)
+VERIFY_RETRIES = 1     # a burst can drop the verify handshake even on the real server
 
 
-def get_local_subnet() -> str | None:
-    """Get the /24 prefix (e.g. '192.168.1.') of the interface holding the default route."""
+_IPV4 = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
+
+
+def _is_private(ip: str) -> bool:
+    """RFC 1918 ranges only: the phone is always on one of these."""
+    try:
+        a, b = (int(p) for p in ip.split(".")[:2])
+    except ValueError:
+        return False
+    return a == 10 or (a == 172 and 16 <= b <= 31) or (a == 192 and b == 168)
+
+
+def get_local_subnets() -> list[str]:
+    """
+    All local /24 prefixes (e.g. ['192.168.1.']) to scan.
+
+    Uses the default-route interface plus every private address the machine
+    holds, so a VPN owning the default route does not hide the LAN the phone
+    is on. ponytail: parses `ip`/`ifconfig`/`ipconfig` output, the stdlib has
+    no cross-platform interface-address API; switch to a lib only if a format
+    stops matching.
+    """
+    prefixes = set()
+
+    # Default-route interface (no shelling out; also covers odd setups)
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
             s.connect(("8.8.8.8", 80))  # UDP connect sends nothing; it just picks the outbound interface
-            return s.getsockname()[0].rsplit(".", 1)[0] + "."
+            ip = s.getsockname()[0]
+            if _is_private(ip):
+                prefixes.add(ip.rsplit(".", 1)[0] + ".")
     except OSError:
-        return None
+        pass
+
+    # Every other interface (the LAN the VPN's default route masks)
+    for cmd in (["ip", "-4", "-o", "addr"], ["ifconfig"], ["ipconfig"]):
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True, timeout=2).stdout
+        except (OSError, subprocess.SubprocessError):
+            continue  # command not on this OS; try the next
+        prefixes.update(
+            ip.rsplit(".", 1)[0] + "."
+            for ip in _IPV4.findall(out)
+            if _is_private(ip) and not ip.endswith(".0")
+        )
+        break  # first command that ran is authoritative
+
+    return sorted(prefixes)
 
 
 def probe_host(ip: str, port: int) -> str | None:
@@ -86,8 +129,9 @@ def probe_and_verify(ip: str, port: int) -> str | None:
     """Fast TCP probe, then verify the host actually speaks the RemotePhone protocol."""
     if probe_host(ip, port) is None:
         return None
-    if is_remotephone_server(ip, port):
-        return ip
+    for _ in range(1 + VERIFY_RETRIES):
+        if is_remotephone_server(ip, port):
+            return ip
     return None
 
 
@@ -110,24 +154,42 @@ class NetworkScanner(QObject):
         self.scan_started.emit()
 
     def _scan(self, port: int):
-        """Scan the local /24 subnet."""
-        prefix = get_local_subnet()
-        if not prefix:
+        """Scan every local /24 subnet."""
+        prefixes = get_local_subnets()
+        if not prefixes:
             log.warning("Could not determine local subnet")
             self._scanning = False
             self.scan_complete.emit([])
             return
 
-        log.info(f"Scanning {prefix}0/24 for port {port}")
-        found = []
-        targets = [f"{prefix}{i}" for i in range(1, 255)]  # skip .0 and .255
+        log.info(f"Scanning {', '.join(p + '0/24' for p in prefixes)} for port {port}")
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
-            for future in as_completed([pool.submit(probe_and_verify, ip, port) for ip in targets]):
-                result = future.result()
-                if result:
-                    log.info(f"Found RemotePhone server at {result}:{port}")
-                    found.append(result)
+        def sweep() -> list[str]:
+            hits = []
+            # One subnet at a time: blasting every /24 at once overloads the phone's
+            # radio and drops SYNs, so a scan across several interfaces misses it.
+            for prefix in prefixes:
+                targets = [f"{prefix}{i}" for i in range(1, 255)]  # skip .0 and .255
+                with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+                    for future in as_completed([pool.submit(probe_and_verify, ip, port) for ip in targets]):
+                        result = future.result()
+                        if result:
+                            log.info(f"Found RemotePhone server at {result}:{port}")
+                            hits.append(result)
+            return hits
+
+        # A lost SYN on WiFi can hide the phone; an empty result is worth one retry.
+        found = sweep() or sweep()
 
         self._scanning = False
         self.scan_complete.emit(found)
+
+
+if __name__ == "__main__":
+    # ponytail check: classification and that a VPN default route no longer hides the LAN
+    assert _is_private("192.168.1.6") and _is_private("10.8.0.33") and _is_private("172.16.5.4")
+    assert not _is_private("8.8.8.8") and not _is_private("172.32.0.1") and not _is_private("169.254.1.1")
+    subs = get_local_subnets()
+    print("subnets to scan:", subs)
+    assert all(s.endswith(".") and _is_private(s + "1") for s in subs), subs
+    print("ok")

--- a/remotephone/network/ws_client.py
+++ b/remotephone/network/ws_client.py
@@ -43,6 +43,7 @@ class WebSocketClient(QObject):
     reconnecting = pyqtSignal(int)   # attempt number
     frame_received = pyqtSignal(int, int, bytes)  # frame_type, timestamp, payload (audio only)
     info_received = pyqtSignal(dict)
+    clipboard_received = pyqtSignal(str)
     error_occurred = pyqtSignal(str)
 
     def __init__(self, parent=None):
@@ -167,6 +168,8 @@ class WebSocketClient(QObject):
 
             if msg_type == "info":
                 self.info_received.emit(obj)
+            elif msg_type == "clipboard":
+                self.clipboard_received.emit(obj.get("content", ""))
             elif msg_type == "error":
                 self.error_occurred.emit(obj.get("message", "Unknown error"))
         except json.JSONDecodeError:

--- a/remotephone/ui/main_window.py
+++ b/remotephone/ui/main_window.py
@@ -6,7 +6,7 @@ Displays the mirrored phone screen and captures input for remote control.
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QLabel, QLineEdit, QPushButton, QStatusBar,
-    QSizePolicy, QCheckBox
+    QSizePolicy, QCheckBox, QMessageBox
 )
 from PyQt6.QtCore import Qt, QRectF, QTimer
 from PyQt6.QtGui import QImage, QPainter, QColor, QFont, QKeyEvent
@@ -18,6 +18,30 @@ from remotephone.decoder.audio_player import AudioPlayer
 from remotephone.input.input_handler import InputHandler
 
 _BACK = {"type": "key", "action": "back"}
+
+# (key, action) rows for the help dialog and the ? button tooltip. Mirrors the
+# gesture and key handling in input_handler.py.
+SHORTCUTS = [
+    ("Left click", "Tap"),
+    ("Click + drag", "Swipe"),
+    ("Hold click (>0.5s)", "Long press"),
+    ("Scroll wheel / two fingers", "Scroll"),
+    ("Two-finger swipe right", "Back"),
+    ("Right / middle click", "Back"),
+    ("Esc", "Back"),
+    ("Home", "Home"),
+    ("F2", "Recent apps"),
+    ("F5", "Notifications"),
+    ("F6", "Quick Settings"),
+    ("F10", "Lock screen"),
+    ("F11", "Fullscreen toggle"),
+    ("Type", "Text into the focused field"),
+    ("Backspace", "Delete (or Back if no field)"),
+    ("Delete", "Delete forward"),
+    ("Enter", "Confirm / submit"),
+    ("Ctrl+A / C / X / V", "Select all / Copy / Cut / Paste"),
+]
+SHORTCUTS_TOOLTIP = "\n".join(f"{k}\u2003{a}" for k, a in SHORTCUTS)
 
 
 class VideoWidget(QWidget):
@@ -245,16 +269,23 @@ class MainWindow(QMainWindow):
         self.fps_label = QLabel("")
         self.resolution_label = QLabel("")
 
+        self.shortcuts_btn = QPushButton("\u2328 Shortcuts")  # keyboard glyph
+        self.shortcuts_btn.setObjectName("shortcutsBtn")
+        self.shortcuts_btn.setToolTip(SHORTCUTS_TOOLTIP)  # hover for the list, click for the dialog
+        self.shortcuts_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+
         self.status_bar.addWidget(self.status_label, 1)
         self.status_bar.addPermanentWidget(self.resolution_label)
         self.status_bar.addPermanentWidget(self.device_label)
         self.status_bar.addPermanentWidget(self.fps_label)
+        self.status_bar.addPermanentWidget(self.shortcuts_btn)
 
     def _setup_connections(self):
         # Connection
         self.connect_btn.clicked.connect(self._on_connect_clicked)
         self.ip_input.returnPressed.connect(self._on_connect_clicked)
         self.scan_btn.clicked.connect(self._on_scan_clicked)
+        self.shortcuts_btn.clicked.connect(self._show_shortcuts)
 
         # Scanner signals
         self.scanner.scan_started.connect(self._on_scan_started)
@@ -318,6 +349,16 @@ class MainWindow(QMainWindow):
             }
             #scanBtn:disabled {
                 color: #6B7280;
+            }
+            #shortcutsBtn {
+                background: transparent;
+                border: none;
+                color: #9CA3AF;
+                font-size: 12px;
+                padding: 0 6px;
+            }
+            #shortcutsBtn:hover {
+                color: #FFFFFF;
             }
             #connectBtn {
                 background-color: #7C3AED;
@@ -516,6 +557,17 @@ class MainWindow(QMainWindow):
     def _send_command(self, cmd: dict):
         if self.connected:
             self.ws_client.send_command(cmd)
+
+    def _show_shortcuts(self):
+        rows = "".join(
+            f"<tr><td style='padding-right:16px'><b>{k}</b></td><td>{a}</td></tr>"
+            for k, a in SHORTCUTS
+        )
+        box = QMessageBox(self)
+        box.setWindowTitle("Keyboard & mouse shortcuts")
+        box.setTextFormat(Qt.TextFormat.RichText)
+        box.setText(f"<table cellspacing='4'>{rows}</table>")
+        box.exec()
 
     # ── Audio toggle ──
 

--- a/remotephone/ui/main_window.py
+++ b/remotephone/ui/main_window.py
@@ -4,7 +4,7 @@ Displays the mirrored phone screen and captures input for remote control.
 """
 
 from PyQt6.QtWidgets import (
-    QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QLabel, QLineEdit, QPushButton, QStatusBar,
     QSizePolicy, QCheckBox
 )
@@ -266,6 +266,7 @@ class MainWindow(QMainWindow):
         self.ws_client.reconnecting.connect(self._on_reconnecting)
         self.ws_client.frame_received.connect(self._on_frame_received)
         self.ws_client.info_received.connect(self._on_info_received)
+        self.ws_client.clipboard_received.connect(self._on_clipboard_received)
         self.ws_client.error_occurred.connect(self._on_error)
 
         # Give decoder a direct reference so WS thread can feed frames
@@ -428,6 +429,10 @@ class MainWindow(QMainWindow):
         if info.get("audioAvailable", False):
             self.audio_checkbox.setEnabled(True)
 
+    def _on_clipboard_received(self, content: str):
+        QApplication.clipboard().setText(content)
+        self.status_label.setText(f"Copied to clipboard ({len(content)} chars)")
+
     def _on_error(self, error: str):
         self.status_label.setText(f"⚠ {error}")
         if not self.connected:
@@ -492,6 +497,12 @@ class MainWindow(QMainWindow):
         # Holding a key repeats text/backspace/delete/enter, but never system keys (back, home, ...)
         if event.isAutoRepeat() and not (cmd and cmd["type"] in ("text", "backspace", "delete")):
             return
+        # Ctrl+V types the desktop clipboard into the phone; the phone's own
+        # clipboard paste stays as fallback when the desktop clipboard is empty
+        if cmd and cmd["type"] == "paste":
+            text = QApplication.clipboard().text()
+            if text:
+                cmd = {"type": "text", "content": text}
         if cmd:
             self._send_command(cmd)
         elif event.key() == Qt.Key.Key_F11:


### PR DESCRIPTION
Fixes flaky typing in browser and other non-native fields, adds two-way clipboard sync, makes auto-discovery work across interfaces, and bumps the version to 1.3.0.

## Typing

- **Android 13+ (feat):** the accessibility service declares `flagInputMethodEditor` and holds its own `InputConnection` to the focused editor, so text/edit/clipboard actions go through the real input pipeline **while the user keeps their normal keyboard selected**. Fixes typing in web pages (Chromium virtual nodes that accessibility SET_TEXT could not drive) with no keyboard switching.
- **Android 12 and older (feat):** a minimal `RemoteInputMethodService` provides the same pipeline when selected; its setup card shows only on those versions. Accessibility SET_TEXT remains the last-resort fallback.
- Enter is sent as a key event so pages and search boxes react to it.
- **Lock keypad (fix):** PIN/password fields are pad button-grids, not editors, so they now bypass the input-connection paths and click the on-screen pad. Without this the 13+ path swallowed digits on the lock screen and broke remote unlock.

## Clipboard

- Ctrl+V types the desktop clipboard into the phone as one string (phone-side paste stays as fallback).
- Ctrl+C / Ctrl+X mirror back: the phone returns the copied text and the client puts it on the desktop clipboard. The copy handler captures the selection through the service's InputConnection, so this no longer needs an active IME to read the clipboard.

## Discovery

- **VPN / multi-interface (fix):** the scan used the single default-route interface, which is the VPN when one is up, so it swept the tunnel and missed the LAN. It now enumerates every private (RFC 1918) interface and scans each /24, one subnet at a time, with a verify retry and an empty-result retry to survive WiFi SYN loss. Found the phone in 8/8 scans behind a VPN (previously 0/8).

## UI / misc

- **Shortcuts reference (feat):** a status-bar button opens a dialog of every mouse/key mapping and shows it as a hover tooltip.
- **Crash on open (fix):** reading `Settings.Secure.ENABLED_INPUT_METHODS` throws on targetSdk 34 (Vivo); use `InputMethodManager.getEnabledInputMethodList`.
- **CI:** bump `checkout`/`upload-artifact`/`download-artifact` to v5, `setup-java` to v5, `setup-python` to v6 (Node 20 deprecation).
- **Version:** 1.3.0 (versionCode 6), with an F-Droid changelog.

## Testing

- Android 14 emulator, driven through the WebSocket protocol: with Gboard active and the RemotePhone keyboard uninvolved, typing/backspace/copy into a Chrome web field land and mirror back; locked with a PIN, remote digits + Enter unlock the device.
- Physical Android 14 device over WiFi: installs, opens without crashing, connects and mirrors.
- Python: compileall, test_input_handler, scanner self-check; Android clean assembleDebug + assembleRelease.

## Notes

- The RemotePhone Keyboard is kept for Android 7-12 support (remote typing in browsers there needs it); on 13+ it is unused and its card hidden.